### PR TITLE
test: 비관적 락을 이용한 동시성 제어

### DIFF
--- a/src/main/java/com/concurrencystudy/service/CouponServiceV3.java
+++ b/src/main/java/com/concurrencystudy/service/CouponServiceV3.java
@@ -1,0 +1,34 @@
+package com.concurrencystudy.service;
+
+import com.concurrencystudy.domain.Coupon;
+import com.concurrencystudy.domain.CouponRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 비관적 락 (Pessimistic Lock)
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CouponServiceV3 {
+
+    private final CouponRepository couponRepository;
+
+    @Transactional
+    public void issueCoupon(Long couponId) {
+        Coupon coupon = couponRepository.findByIdWithPessimisticLock(couponId)
+                .orElseThrow(() -> new IllegalArgumentException("쿠폰을 찾을 수 없습니다."));
+
+        if (coupon.isAvailable()) {
+            coupon.issue();
+            couponRepository.save(coupon);
+            log.info("쿠폰 발급 성공! 남은 수량: {}", coupon.getTotalQuantity() - coupon.getIssuedQuantity());
+        } else {
+            log.warn("쿠폰이 모두 소진되었습니다.");
+            throw new IllegalStateException("쿠폰이 모두 소진되었습니다.");
+        }
+    }
+}

--- a/src/test/java/com/concurrencystudy/service/CouponServiceV3Test.java
+++ b/src/test/java/com/concurrencystudy/service/CouponServiceV3Test.java
@@ -1,0 +1,77 @@
+package com.concurrencystudy.service;
+
+import com.concurrencystudy.domain.Coupon;
+import com.concurrencystudy.domain.CouponRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 비관적 락 테스트
+ */
+@SpringBootTest
+class CouponServiceV3Test {
+
+    @Autowired
+    private CouponServiceV3 couponServiceV3;
+
+    @Autowired
+    private CouponRepository couponRepository;
+
+    @BeforeEach
+    void setUp() {
+        couponRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("비관적 락으로 동시성 제어 - 데이터 정합성 보장")
+    void pessimisticLockTest() throws InterruptedException {
+        // given
+        Coupon coupon = Coupon.create("선착순 쿠폰", 100);
+        Coupon saved = couponRepository.save(coupon);
+        Long couponId = saved.getId();
+
+        int threadCount = 100;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        AtomicInteger successCount = new AtomicInteger();
+        AtomicInteger failCount = new AtomicInteger();
+
+        // when
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    couponServiceV3.issueCoupon(couponId);
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    failCount.incrementAndGet();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+        executorService.shutdown();
+
+        // then
+        Coupon result = couponRepository.findById(couponId).orElseThrow();
+        System.out.println("=========================================");
+        System.out.println("총 요청 수: " + threadCount);
+        System.out.println("성공한 요청 수: " + successCount.get());
+        System.out.println("실패한 요청 수: " + failCount.get());
+        System.out.println("실제 발급된 쿠폰 수: " + result.getIssuedQuantity());
+        System.out.println("=========================================");
+
+        assertThat(result.getIssuedQuantity()).isEqualTo(100);
+    }
+}


### PR DESCRIPTION
## 🔎 작업 내용
* DB 레벨에서의 동시성 제어를 구현하여 분산 환경에서도 동작하는 비관적 락을 적용
* JPA `@Lock(LockModeType.PESSIMISTIC_WRITE)` 사용
* SELECT ... FOR UPDATE 쿼리로 데이터 정합성 보장
* 분산 환경에서도 동작하는 DB 레벨 락 구현
## ➕ 이슈 링크
* #7 

## 📸 스크린샷(선택)
<img width="2314" height="1062" alt="image" src="https://github.com/user-attachments/assets/d876bc10-bc98-43ba-82c3-10e67c499dc7" />


## 😎 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
<!--ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?-->
## 🧑‍💻 예정 작업
- #

## 📝 체크리스트
- [x] 브랜치 이름은 `feature/개발내용` 형식으로 작성했는가?
- [x] 커밋 메시지는 `feat: 커밋 내용` 형식으로 작성했는가?
- [x] 작업 전 Issue를 작성했는가?
- [x] `dev` 브랜치로 병합을 요청했는가?
- [x] 불필요한 주석과 공백은 제거했는가?
- [ ] 코드 리뷰어의 피드백을 반영했는가?
- [x] 테스트를 진행했는가?
- [x] 테스트 코드를 작성했는가?
- 
